### PR TITLE
Remove x from Resource Examples

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/powershell
+{
+	"name": "PowerShell",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/powershell:lts-debian-11",
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": "true",
+			"username": "vscode",
+			"upgradePackages": "false",
+			"nonFreePackages": "true"
+		}
+	},
+
+	"postCreateCommand": [
+        "sudo chsh vscode -s \"$(which pwsh)\"",
+        "pwsh -c 'Install-Module -Name PSScriptAnalyzer, Datum, Datum.InvokeCommand, Pester, PSDesiredStateConfiguration -Force'"
+    ],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"terminal.integrated.defaultProfile.linux": "pwsh"
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-vscode.powershell", 
+				"donjayamanne.githistory",
+				"eamodio.gitlens",
+				"editorconfig.editorconfig",
+				"esbenp.prettier-vscode",
+				"mhutchie.git-graph",
+				"ms-azuretools.azure-dev",
+				"ms-azuretools.vscode-docker",
+				"ms-vscode-remote.remote-containers",
+				"ms-vscode-remote.remote-ssh",
+				"ms-vscode-remote.remote-ssh-edit",
+				"ms-vscode-remote.remote-wsl",
+				"ms-vscode.powershell",
+				"ncodefun.simple-focus-web",
+				"pflannery.vscode-versionlens",
+				"redhat.vscode-yaml",
+				"wayou.vscode-todo-highlight"
+			]
+		}
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/workflows/CodeCoverage.yml
+++ b/.github/workflows/CodeCoverage.yml
@@ -30,5 +30,5 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Run tests.ps1 - Perform Code Coverage
         shell: pwsh
-        run: . /tests.ps1
+        run: . \tests.ps1
           

--- a/.github/workflows/CodeCoverage.yml
+++ b/.github/workflows/CodeCoverage.yml
@@ -24,6 +24,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
+      - name: Download PowerShell Dependencies
+        shell: pwsh
+        run: Install-Module Datum, Datum.InvokeCommand, powershell-yaml, PSDesiredStateConfiguration -Force
+
       - name: Perform a Pester Test to ensure that the .\tests.ps1 script exists
         shell: pwsh
         run: Test-Path .\tests.ps1 | Should -be $true

--- a/.github/workflows/CodeCoverage.yml
+++ b/.github/workflows/CodeCoverage.yml
@@ -1,0 +1,34 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Run Code Coverage
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+  pull_request:
+    branches: [ "*" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - name: Perform a Pester Test to ensure that the .\tests.ps1 script exists
+        shell: pwsh
+        run: Test-Path .\tests.ps1 | Should -be $true
+      # Runs a set of commands using the runners shell
+      - name: Run tests.ps1 - Perform Code Coverage
+        shell: pwsh
+        run: . /tests.ps1
+          

--- a/.github/workflows/CodeCoverage.yml
+++ b/.github/workflows/CodeCoverage.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Perform a Pester Test to ensure that the .\tests.ps1 script exists
         shell: pwsh
         run: Test-Path .\tests.ps1 | Should -be $true
+        
       # Runs a set of commands using the runners shell
       - name: Run tests.ps1 - Perform Code Coverage
         shell: pwsh
-        run: . \tests.ps1
+        run: . .\tests.ps1
           

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,91 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '20 2 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['csharp']
+         
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 output/*
-.devcontainer/
 internal-tests/
 LCM/Datum/*
 

--- a/Example Configuration/ProjectPolicies/Project.yml
+++ b/Example Configuration/ProjectPolicies/Project.yml
@@ -9,7 +9,7 @@ variables: {
 resources:
 
   - name: Project
-    type: AzureDevOpsDsc/xAzDoProject
+    type: AzureDevOpsDsc/AzDoProject
     postExecutionScript: if ($Project_Ensure -eq 'Absent') { Stop-TaskProcessing }
     properties:
       projectName: $ProjectName
@@ -20,9 +20,9 @@ resources:
       Ensure: $( if ([string]::IsNullOrEmpty($Project_Ensure)) { 'Present' } else { $Project_Ensure } )
 
   - name: Project Services
-    type: AzureDevOpsDsc/xAzDoProjectServices
+    type: AzureDevOpsDsc/AzDoProjectServices
     dependsOn: 
-      - AzureDevOpsDsc/xAzDoProject/Project
+      - AzureDevOpsDsc/AzDoProject/Project
     properties:
       projectName: $ProjectName
       GitRepositories: $( if ([string]::IsNullOrEmpty($Project_Service_GitRepositories)) { 'disabled' } else { $Project_Service_GitRepositories } )

--- a/Example Configuration/ProjectPolicies/ProjectGitRepositories.yml
+++ b/Example Configuration/ProjectPolicies/ProjectGitRepositories.yml
@@ -7,11 +7,11 @@ variables: {
 resources:
 
   - name: Default Git Configuration Permissions
-    type: AzureDevOpsDsc/xAzDoGitPermission
+    type: AzureDevOpsDsc/AzDoGitPermission
     dependsOn:
-      - AzureDevOpsDsc/xAzDoProject/Project
-      - AzureDevOpsDsc/xAzDoProjectGroup/CON Readers
-      - AzureDevOpsDsc/xAzDoProjectGroup/CON Board Administrators
+      - AzureDevOpsDsc/AzDoProject/Project
+      - AzureDevOpsDsc/AzDoProjectGroup/CON Readers
+      - AzureDevOpsDsc/AzDoProjectGroup/CON Board Administrators
     properties:
       ProjectName: $ProjectName
       RepositoryName: $ProjectName

--- a/Example Configuration/ProjectPolicies/ProjectGroups.yml
+++ b/Example Configuration/ProjectPolicies/ProjectGroups.yml
@@ -12,9 +12,9 @@ variables: {
 resources:
 
   - name: CON Readers
-    type: AzureDevOpsDsc/xAzDoProjectGroup
+    type: AzureDevOpsDsc/AzDoProjectGroup
     dependsOn: 
-      - AzureDevOpsDsc/xAzDoProject/Project
+      - AzureDevOpsDsc/AzDoProject/Project
     properties:
       ProjectName: $ProjectName
       GroupName: $ProjectGroups_Role_CONReaders
@@ -22,9 +22,9 @@ resources:
 
   - name: CON Board Administrators
     condition: $ProjectWorkBoardsStatus -eq 'enabled'
-    type: AzureDevOpsDsc/xAzDoProjectGroup
+    type: AzureDevOpsDsc/AzDoProjectGroup
     dependsOn: 
-      - AzureDevOpsDsc/xAzDoProject/Project
+      - AzureDevOpsDsc/AzDoProject/Project
     properties:
       ProjectName: $ProjectName
       GroupName: $ProjectGroups_Role_CONBoardAdministrators

--- a/Example Configuration/Projects/Present/Magenta.yml
+++ b/Example Configuration/Projects/Present/Magenta.yml
@@ -11,19 +11,19 @@ variables: {
 resources:
 
 - name: Configuration Git Repository
-  type: AzureDevOpsDsc/xAzDoGitRepository
+  type: AzureDevOpsDsc/AzDoGitRepository
   dependsOn: 
-    - AzureDevOpsDsc/xAzDoProject/Project
+    - AzureDevOpsDsc/AzDoProject/Project
   properties:
     ProjectName: $ProjectName
     RepositoryName: $ProjectRepositoryName
 
 - name: Configuration Git Permissions
-  type: AzureDevOpsDsc/xAzDoGitPermission
+  type: AzureDevOpsDsc/AzDoGitPermission
   dependsOn: 
-    - AzureDevOpsDsc/xAzDoGitRepository/Configuration Git Repository
-    - AzureDevOpsDsc/xAzDoProjectGroup/CON Readers
-    - AzureDevOpsDsc/xAzDoProjectGroup/CON Board Administrators
+    - AzureDevOpsDsc/AzDoGitRepository/Configuration Git Repository
+    - AzureDevOpsDsc/AzDoProjectGroup/CON Readers
+    - AzureDevOpsDsc/AzDoProjectGroup/CON Board Administrators
   properties:
     ProjectName: $ProjectName
     RepositoryName: $ProjectRepositoryName

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This LCM utilizes Datum from Gael Colas to streamline configuration. For more in
     ```yaml
     - name: CON Board Administrators
       condition: $ProjectWorkBoardsStatus -eq 'enabled'
-      type: AzureDevOpsDsc/xAzDoProjectGroup
+      type: AzureDevOpsDsc/AzDoProjectGroup
       dependsOn:
-        - AzureDevOpsDsc/xAzDoProject/Project
+        - AzureDevOpsDsc/AzDoProject/Project
       properties:
         ProjectName: $ProjectName
         GroupName: $GroupName
@@ -63,7 +63,7 @@ The Local Configuration Manager (LCM) provides a set of features applicable to a
     ```yaml
     - name: CON Board Administrators
       condition: $ProjectWorkBoardsStatus -eq 'enabled'
-      type: AzureDevOpsDsc/xAzDoProjectGroup
+      type: AzureDevOpsDsc/AzDoProjectGroup
     ```
 
 - __postExecutionScript__: This feature triggers a script after the resource has been executed. It can be used to perform additional operations or clean-up tasks following the resource's execution. This is helpful for managing state changes or handling post-execution logic.
@@ -72,7 +72,7 @@ The Local Configuration Manager (LCM) provides a set of features applicable to a
 
     ```yaml
     - name: Project
-      type: AzureDevOpsDsc/xAzDoProject
+      type: AzureDevOpsDsc/AzDoProject
       postExecutionScript: if ($Project_Ensure -eq 'Absent') { Stop-TaskProcessing }
     ```
 
@@ -82,11 +82,11 @@ The Local Configuration Manager (LCM) provides a set of features applicable to a
 
     ```yaml
     - name: Default Git Configuration Permissions
-      type: AzureDevOpsDsc/xAzDoGitPermission
+      type: AzureDevOpsDsc/AzDoGitPermission
       dependsOn:
-        - AzureDevOpsDsc/xAzDoProject/Project
-        - AzureDevOpsDsc/xAzDoProjectGroup/CON Readers
-        - AzureDevOpsDsc/xAzDoProjectGroup/CON Board Administrators
+        - AzureDevOpsDsc/AzDoProject/Project
+        - AzureDevOpsDsc/AzDoProjectGroup/CON Readers
+        - AzureDevOpsDsc/AzDoProjectGroup/CON Board Administrators
     ```
 
 These features collectively enhance the robustness and adaptability of DSC resources managed by the LCM, allowing for more precise and context-sensitive configuration management.
@@ -99,7 +99,7 @@ In the realm of configuration, there are specialized commands designed to modify
 
     ```yaml
     - name: Project
-        type: AzureDevOpsDsc/xAzDoProject
+        type: AzureDevOpsDsc/AzDoProject
         postExecutionScript: if ($Project_Ensure -eq 'Absent') { Stop-TaskProcessing }
     ```
 

--- a/Tests/LCM/DSCConfiguration/Private/DatumHelper/Clone-Repository.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Private/DatumHelper/Clone-Repository.tests.ps1
@@ -12,7 +12,7 @@ Describe 'Clone-Repository Function Tests' {
 
    
 
-        Mock New-TemporaryDirectory { return "C:\Temp\Repo" }
+        Mock New-TemporaryDirectory { return (New-MockDirectoryPath) }
         Mock git
 
     }

--- a/Tests/LCM/DSCConfiguration/Private/DatumHelper/DatumConfigurationScriptBlock.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Private/DatumHelper/DatumConfigurationScriptBlock.tests.ps1
@@ -26,7 +26,7 @@ Describe 'DatumConfigurationScriptBlock Function Tests' {
             # Simulate direct execution
             $MyInvocation = [PSCustomObject]@{ MyCommand = [PSCustomObject]@{ Name = 'DatumConfigurationScriptBlock' } }
             
-            { DatumConfigurationScriptBlock -OutputPath "C:\Output" -ConfigurationPath "C:\Configuration" } | Should -Throw  "This function is intended to be used as a script block in a separate thread using the Build-DatumConfiguration function."
+            { DatumConfigurationScriptBlock -OutputPath (New-MockDirectoryPath) -ConfigurationPath (New-MockDirectoryPath) } | Should -Throw  "This function is intended to be used as a script block in a separate thread using the Build-DatumConfiguration function."
 
         }
     }
@@ -35,7 +35,7 @@ Describe 'DatumConfigurationScriptBlock Function Tests' {
 
         It "Should import all necessary modules" {
             # Execute the function in a simulated environment
-            DatumConfigurationScriptBlock -OutputPath "C:\Output" -configurationPath "C:\Configuration" -isTest
+            DatumConfigurationScriptBlock -OutputPath (New-MockDirectoryPath) -configurationPath (New-MockDirectoryPath) -isTest
 
             # Verify that Import-Module was called with expected parameters
             Assert-MockCalled -CommandName Import-Module -Exactly 1 -Scope It -ParameterFilter { 
@@ -50,16 +50,18 @@ Describe 'DatumConfigurationScriptBlock Function Tests' {
     Context "Directory Change Verification" {
 
         It "Should change the current directory to the specified configuration path" {
-            DatumConfigurationScriptBlock -OutputPath "C:\Output" -ConfigurationPath "C:\Configuration" -isTest
 
-            Assert-MockCalled -CommandName Set-Location -Exactly 1 -ParameterFilter { $Path -eq 'C:\Configuration' }
+            $ConfigurationPath = New-MockDirectoryPath
+            DatumConfigurationScriptBlock -OutputPath (New-MockDirectoryPath) -ConfigurationPath $ConfigurationPath -isTest
+
+            Assert-MockCalled -CommandName Set-Location -Exactly 1 -ParameterFilter { $Path -eq $ConfigurationPath }
         }
     }
 
     Context "Datum Structure Creation" {
 
         It "Should create a new Datum structure from the definition file" {
-            DatumConfigurationScriptBlock -OutputPath "C:\Output" -ConfigurationPath "C:\Configuration" -isTest
+            DatumConfigurationScriptBlock -OutputPath (New-MockDirectoryPath) -ConfigurationPath (New-MockDirectoryPath) -isTest
 
             Assert-MockCalled -CommandName New-DatumStructure -Times 1
         }
@@ -68,7 +70,7 @@ Describe 'DatumConfigurationScriptBlock Function Tests' {
     Context "Configuration Testing" {
 
         It "Should test the Datum configuration" {
-            DatumConfigurationScriptBlock -OutputPath "C:\Output" -ConfigurationPath "C:\Configuration" -isTest
+            DatumConfigurationScriptBlock -OutputPath (New-MockDirectoryPath) -ConfigurationPath (New-MockDirectoryPath) -isTest
 
             Assert-MockCalled -CommandName Test-DatumConfiguration -Exactly 1
         }
@@ -89,7 +91,7 @@ Describe 'DatumConfigurationScriptBlock Function Tests' {
                 }
             }
 
-            DatumConfigurationScriptBlock -OutputPath "C:\Output" -ConfigurationPath "C:\Configuration" -isTest
+            DatumConfigurationScriptBlock -OutputPath (New-MockDirectoryPath) -ConfigurationPath (New-MockDirectoryPath) -isTest
 
             Assert-MockCalled -CommandName Resolve-AzDoDatumProject -Exactly 2 -Scope It
         }

--- a/Tests/LCM/DSCConfiguration/Private/DatumHelper/New-TemporaryDirectory.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Private/DatumHelper/New-TemporaryDirectory.tests.ps1
@@ -9,9 +9,10 @@ Describe 'New-TemporaryDirectory Function Tests' {
 
         Mock -CommandName New-Item -MockWith {
             param($ItemType, $Path)
+            $path = New-MockDirectoryPath
             return @{
-                PSPath = "Microsoft.PowerShell.Core\FileSystem::C:\Temp\SomeRandomDir"
-                PSParentPath = "Microsoft.PowerShell.Core\FileSystem::C:\Temp"
+                PSPath = "Microsoft.PowerShell.Core\FileSystem::$(New-MockDirectoryPath)"
+                PSParentPath = "Microsoft.PowerShell.Core\FileSystem::$(New-MockDirectoryPath)"
                 PSChildName = "SomeRandomDir"
                 PSDrive = @{ Name = "C" }
                 PSProvider = @{ Name = "FileSystem" }
@@ -19,8 +20,8 @@ Describe 'New-TemporaryDirectory Function Tests' {
                 BaseName = "SomeRandomDir"
                 Mode = "d----"
                 Name = "SomeRandomDir"
-                FullName = "C:\Temp\SomeRandomDir"
-                Parent = "C:\Temp"
+                FullName = "$path\SomeRandomDir"
+                Parent = $path
             }
         }
 

--- a/Tests/LCM/DSCConfiguration/Private/DatumHelper/git.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Private/DatumHelper/git.tests.ps1
@@ -8,10 +8,11 @@ Describe 'git Function Tests' {
         . $preParseFilePath
 
         Mock Get-Command {
+            
             return @{
                 Name = 'git'
                 CommandType = 'Application'
-                Definition = 'C:\Program Files\Git\bin\git.exe'
+                Definition = New-MockFilePath 'git.exe'
             }
         }
 

--- a/Tests/LCM/DSCConfiguration/Public/Build-DatumConfiguration.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Public/Build-DatumConfiguration.tests.ps1
@@ -86,7 +86,7 @@ Describe "Start-LCM Function Tests" -Tag Unit {
 
         It "Should throw an error if ConfigurationPath does not exist" {
             $outputPath = Join-Path $TestDrive "TestOutput"
-            $invalidPath = "C:\NonExistentPath"
+            $invalidPath = New-MockDirectoryPath
 
             New-Item -ItemType Directory -Path $outputPath -Force | Out-Null
 

--- a/Tests/LCM/DSCConfiguration/Public/Compile-DatumConfiguration.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Public/Compile-DatumConfiguration.tests.ps1
@@ -35,35 +35,38 @@ Describe "Compile-DatumConfiguration Function Tests" -Tag Unit -Skip {
             }
         }
 
+        $OutputPath = New-MockDirectoryPath
+        $ConfigurationPath = New-MockDirectoryPath
 
     }
 
     It "should clear the output directory" {
-        Compile-DatumConfiguration -OutputPath "C:\FakeOutput" -ConfigurationPath "C:\FakeConfig"
+
+        Compile-DatumConfiguration -OutputPath $OutputPath -ConfigurationPath $ConfigurationPath
 
         # Verify that Get-ChildItem was called with the correct parameters
-        Assert-MockCalled -CommandName Get-ChildItem -Exactly 1 -Scope It -ParameterFilter { $_.LiteralPath -eq "C:\FakeOutput" }
+        Assert-MockCalled -CommandName Get-ChildItem -Exactly 1 -Scope It -ParameterFilter { $_.LiteralPath -eq $OutputPath }
         
         # Verify that Remove-Item was called
         Assert-MockCalled -CommandName Remove-Item -AtLeast 0 -Scope It
     }
 
     It "should import necessary modules" {
-        Compile-DatumConfiguration -OutputPath "C:\FakeOutput" -ConfigurationPath "C:\FakeConfig"
+        Compile-DatumConfiguration -OutputPath $OutputPath -ConfigurationPath $ConfigurationPath
 
         # Verify that Import-Module was called for each required module
         Assert-MockCalled -CommandName Import-Module -Exactly 3 -Scope It
     }
 
     It "should create a Datum structure from definition file" {
-        Compile-DatumConfiguration -OutputPath "C:\FakeOutput" -ConfigurationPath "C:\FakeConfig"
+        Compile-DatumConfiguration -OutputPath $OutputPath -ConfigurationPath $ConfigurationPath
 
         # Verify that New-DatumStructure was called
         Assert-MockCalled -CommandName New-DatumStructure -Exactly 1 -Scope It
     }
 
     It "should resolve configurations for each node" {
-        Compile-DatumConfiguration -OutputPath "C:\FakeOutput" -ConfigurationPath "C:\FakeConfig"
+        Compile-DatumConfiguration -OutputPath $OutputPath -ConfigurationPath $ConfigurationPath
 
         # Verify that Resolve-Datum was called multiple times for different properties
         Assert-MockCalled -CommandName Resolve-Datum -AtLeast 4 -Scope It

--- a/Tests/TestHelpers/CommonTestFunctions.psm1
+++ b/Tests/TestHelpers/CommonTestFunctions.psm1
@@ -14,6 +14,30 @@ Function Split-RecurivePath {
     $Path
 }
 
+function New-MockFilePath {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$FileName
+    )
+
+    Join-Path (New-MockDirectoryPath) $FileName
+    
+}
+
+Function New-MockDirectoryPath {
+    param ()
+
+    if ($null -eq $TestDrive) {
+        $tempPath = Join-Path $env:TEMP 'Pester'
+        $TestDrive = Join-Path $env:TEMP $tempPath
+    }
+
+    Join-Path $TestDrive 'Temp'
+
+}
+
+
+
 Function Get-FunctionPath {
     param(
         [string[]]$FileNames
@@ -106,4 +130,4 @@ Function Import-Enums {
     return ($Global:TestPaths | Where-Object { $_.Directory.Name -eq 'Enum' })
 }
 
-Export-ModuleMember -Function Split-RecurivePath, Get-FunctionPath, Find-Functions, Get-ClassFilePath, Import-Enums
+Export-ModuleMember -Function Split-RecurivePath, Get-FunctionPath, Find-Functions, Get-ClassFilePath, Import-Enums, New-MockDirectoryPath, New-MockFilePath

--- a/source/Public/Invoke-AZDoLCM.ps1
+++ b/source/Public/Invoke-AZDoLCM.ps1
@@ -190,7 +190,7 @@ function Invoke-AZDoLCM {
     postExecutionTask:
 
     - name: Org Group Members
-        type: AzureDevOpsDsc/xAzDoProject
+        type: AzureDevOpsDsc/AzDoProject
         properties:
         projectName: CON_$ProjectName
         projectDescription: $ProjectDescription


### PR DESCRIPTION
This pull request eliminates 'x' from the AzDO DSC Resource module to align it with the AzDo standards highlighted in [https://github.com/dsccommunity/AzureDevOpsDsc/pull/36](https://github.com/dsccommunity/AzureDevOpsDsc/pull/36).

> I noticed that the resources have ’x’ prefix, we can remove that as it is no longer used. We are actively trying to remove the ’x’ from module names and resources throughout the DSC Community. But it can be done in another PR too.
> 
> Impressive work on this one PR 😊
